### PR TITLE
I have added the issue bot and issue-close bot

### DIFF
--- a/.github/workflows/autocomment-iss-close.yml
+++ b/.github/workflows/autocomment-iss-close.yml
@@ -19,7 +19,7 @@ jobs:
             const issueCreator = issue.user.login;
             const issueNumber = issue.number;
 
-            const greetingMessage = `Hello @${issueCreator}! Your issue #${issueNumber} has been closed. Thank you for your contribution!`;
+            const greetingMessage = `Hello @${issueCreator}! Your issue #${issueNumber} ✅ This issue has been successfully closed. Thank you for your contribution and helping us improve the project! If you have any more ideas or run into other issues, feel free to open a new one. Happy coding! 🚀
 
             github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/issue-comment.yml
+++ b/.github/workflows/issue-comment.yml
@@ -1,0 +1,18 @@
+name: Issue Auto Commenter
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment to new issue
+        uses: actions-ecosystem/action-add-comment@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_number: ${{ github.event.issue.number }}
+          comment: |
+            👋 Thanks for opening this issue! We appreciate your contribution. Please make sure you’ve provided all the necessary details and screenshots, and don't forget to follow our Guidelines and Code of Conduct. Happy coding! 🚀


### PR DESCRIPTION
I have added an issue auto-comment bot to our repository, which automatically comments on newly created issues with a friendly message encouraging contributors to provide necessary details and follow guidelines. However, I discovered that there is already an existing bot in place for closing issues. please have a look thank you also add gssoc-ext labels...
resolves issue #3 