### PR TITLE
Fixed #95 and #96

### DIFF
--- a/src/pages/UserProfile.jsx
+++ b/src/pages/UserProfile.jsx
@@ -159,7 +159,7 @@ export default function UserProfile({ username }) {
   }
   return (
     <div className='min-h-screen bg-gray-900 text-white p-8 md:p-16 relative'>
-      <div className='absolute inset-0 bg-gradient-to-tr from-indigo-600 via-purple-600 to-indigo-600 opacity-30 -z-10'></div>
+      <div className='absolute inset-0 bg-gradient-to-tr from-indigo-600 via-purple-600 to-indigo-600 opacity-30 -z-10'></div> 
       {userData && (
         <div className='max-w-6xl mx-auto bg-gray-800 bg-opacity-80 rounded-xl p-8 shadow-lg'>
           <div className='flex flex-col md:flex-row items-center md:items-start gap-8'>
@@ -214,13 +214,13 @@ export default function UserProfile({ username }) {
 
             <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 mt-6'>
               {currentRepos.map((repo) => (
-                <div key={repo.id} className='bg-gray-700 p-6 rounded-lg overflow-hidden shadow-lg'>
+                <div key={repo.id} className='bg-gray-700 p-6 rounded-lg overflow-hidden shadow-lg flex flex-col justify-between'>
                   <h4 className='text-xl font-semibold text-blue-400 hover:underline'>
                     <a href={repo.html_url} target='_blank' rel='noopener noreferrer'>
                       {repo.name}
                     </a>
                   </h4>
-                  <p className='text-gray-300 mt-2'>
+                  <p className='text-gray-300 mt-2 grow'>
                     {repo.description || 'No description available.'}
                   </p>
                   <div className='flex bg-stone-500/10 p-1.5 rounded-md justify-between mt-4 text-gray-400 text-sm'>
@@ -229,7 +229,7 @@ export default function UserProfile({ username }) {
                   </div>
                   <button
                     onClick={() => downloadRepoStats(repo)}
-                    className='mt-4 px-4 py-2 bg-green-600 text-white rounded-md flex items-center gap-2'
+                    className='mt-4 px-4 py-2 bg-green-600 text-white rounded-md flex items-center gap-2 justify-center'
                   >
                     <FaDownload />
                     Stats


### PR DESCRIPTION
All Changes Are In /src/pages/UserProfile.jsx

Fixes #95 
Here's what I did:

1. Added flex flex-col justify-between at Line 217 to push stats button to the bottom of each repository container
2. Added grow at Line 223 so the <p> fills the empty space
3. Added justify-center at Line 232 so the content in stats button is centered.

Here's how it looks now:
![image](https://github.com/user-attachments/assets/1221bd4d-af0f-4674-9703-b1b7b299fc82)

Edit: Fixes #96 
Here's What I did:

1. Imported FaBackward at Line 6
2. Added a <a> link at Line 166 which is the main link to go back to homepage.

Now It Looks Like: 
![image](https://github.com/user-attachments/assets/790134d8-ef46-4205-9aa4-256bbf8b427f)
